### PR TITLE
Update ocr scheme text color

### DIFF
--- a/Sources/W3WSwiftThemes/Presets/Colors/PresetColors.swift
+++ b/Sources/W3WSwiftThemes/Presets/Colors/PresetColors.swift
@@ -75,10 +75,11 @@ extension W3WColors {
   )
   
   static public let standardOcr = W3WColors(
-    foreground: .standardLabelsPrimaryBlackInverse,
+    foreground: .standardLabelsTertiary,
     background: .standardSystemBackgroundBasePrimary,
-    secondary:  .standardSystemBackgroundBaseSecondary,
+    secondary:  .standardLabelsQuaternary,
     secondaryBackground: .standardSystemBackgroundBaseSecondary,
+    brand:      .standardBrandBase,
     border:     .clear,
     separator:  .standardLabelsPrimary,
     success: W3WBasicColors(
@@ -184,10 +185,11 @@ extension W3WColors {
   )
   
   static public let w3wOcr = W3WColors(
-    foreground: .w3wLabelsPrimaryBlackInverse,
+    foreground: .w3wLabelsTertiary,
     background: .w3wSystemBackgroundBasePrimary,
-    secondary:  .w3wSystemBackgroundBaseSecondary,
+    secondary:  .w3wLabelsQuaternary,
     secondaryBackground: .w3wSystemBackgroundBaseSecondary,
+    brand:      .w3wBrandBase,
     border:     .clear,
     separator:  .w3wLabelsPrimary,
     success: W3WBasicColors(

--- a/Sources/W3WSwiftThemes/Themes/Schemes/Colors/Color/W3WColors.swift
+++ b/Sources/W3WSwiftThemes/Themes/Schemes/Colors/Color/W3WColors.swift
@@ -242,6 +242,12 @@ public struct W3WColors {
   }
   
   
+  /// return the same colorset the secondary background color changed
+  public func with(secondaryBackground: W3WColor? = nil) -> W3WColors {
+    return W3WColors(foreground: foreground, background: background, tint: tint, secondary: secondary, secondaryBackground: secondaryBackground, brand: brand, highlight: highlight, border: border, separator: separator, shadow: shadow, placeholder: placeholder, success: success, error: error, header: header, line: line)
+  }
+  
+  
   /// return the same colorset the secondary color changed
   public func with(brand: W3WColor? = nil) -> W3WColors {
     return W3WColors(foreground: foreground, background: background, tint: tint, secondary: secondary, secondaryBackground: secondaryBackground, brand: brand, highlight: highlight, border: border, separator: separator, shadow: shadow, placeholder: placeholder, success: success, error: error, header: header, line: line)


### PR DESCRIPTION
Because the `cells` scheme text colors are now changed to be different with the address cell texts color in the design (and I don't know if it can be changed again in the future), I decide to use the colors in the `ocr` scheme for the bottom sheet cells instead. 
Note that the `foreground`, `secondary`, `brand` colors of "ocr" scheme were not in use anywhere so this change does not effect anything.