### PR TITLE
Add legacy icon name for old iOS

### DIFF
--- a/Sources/W3WSwiftThemes/Presets/Images/PresetIcons.swift
+++ b/Sources/W3WSwiftThemes/Presets/Images/PresetIcons.swift
@@ -158,5 +158,11 @@ public extension W3WImage {
   static let xmarkCircle      = { return W3WImage(systemName: "xmark.circle", colors: .standardIcons) }()
   static let xmarkCircleFill      = { return W3WImage(systemName: "xmark.circle.fill", colors: .standardIcons) }()
   static let w3wCar = { return W3WImage(systemName: "car", colors: .standardIcons) }()
-  static let w3wTextDocument = { return W3WImage(systemName: "text.document", colors: .standardIcons) }()
+  static let w3wTextDocument = {
+    if #available(iOS 18.0, *) {
+      return W3WImage(systemName: "text.document", colors: .standardIcons)
+    } else {
+      return W3WImage(systemName: "doc.text", colors: .standardIcons)
+    }
+  }()
 }


### PR DESCRIPTION
There is a SF symbol which has 2 names for new and legacy iOS version, so I added a availability check for it to ensure it'd display on all supported versions.
<img width="391" alt="image" src="https://github.com/user-attachments/assets/e7f8973e-fa98-44e3-8012-52602c2b7992" />
