### PR TITLE
[MT-8778] Add sunMax and iphone preset icons

### DIFF
--- a/Sources/W3WSwiftThemes/Presets/Images/PresetIcons.swift
+++ b/Sources/W3WSwiftThemes/Presets/Images/PresetIcons.swift
@@ -73,6 +73,8 @@ public extension W3WImage {
   static let micSystem                 = { return W3WImage(systemName: "mic", colors: .standardIcons) }()
   static let moonFill                 = { return W3WImage(systemName: "moon.fill", colors: .standardIcons) }()
   static let moon                    = { return W3WImage(systemName: "moon", colors: .standardIcons) }()
+  static let sunMax                  = { return W3WImage(systemName: "sun.max", colors: .standardIcons) }()
+  static let iphone                  = { return W3WImage(systemName: "iphone", colors: .standardIcons) }()
   static let plus                   = { return W3WImage(systemName: "plus", colors: .standardIcons) }()
   static let rays                  = { return W3WImage(systemName: "rays", colors: .standardIcons) }()
   static let rulerFill            = { return W3WImage(systemName: "ruler.fill", colors: .standardIcons) }()


### PR DESCRIPTION
## What
Add two `W3WImage` system-image presets, following the existing preset style (e.g. `.moon`):
- `.sunMax` → `sun.max`
- `.iphone` → `iphone`

## Why
The iOS app's refactored Dark mode "Appearance" settings screen (MT-8778) uses per-row icons — Light mode (sun), Dark mode (moon, already a preset), Use device settings (iphone). These two presets back the Light mode and Use device settings rows, so the app no longer builds them inline.

## Notes
- Additive only — no existing presets changed.
- A release cut from this is needed before the app can bump its `w3w-swift-themes` dependency to consume them.