### PR TITLE
[MT-8778] Restore watchOS support to main (port of #78)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "w3w-swift-themes",
-  
+
+    platforms: [.watchOS(.v6)],
+
     products: [.library(name: "W3WSwiftThemes", targets: ["W3WSwiftThemes"])],
     targets: [
       .target(name: "W3WSwiftThemes", resources: [.process("Resources")]),

--- a/Sources/W3WSwiftThemes/Design/Schemes/Colors/Color/W3WColor.swift
+++ b/Sources/W3WSwiftThemes/Design/Schemes/Colors/Color/W3WColor.swift
@@ -91,7 +91,7 @@ public class W3WColor {
 
   
 #if canImport(SwiftUI)
-  @available(iOS 13.0, *)
+  @available(iOS 13.0, watchOS 6.0, *)
   public var suColor: Color {
     get {
       return current.suColor

--- a/Sources/W3WSwiftThemes/Design/Schemes/Colors/Color/W3WCoreColor.swift
+++ b/Sources/W3WSwiftThemes/Design/Schemes/Colors/Color/W3WCoreColor.swift
@@ -185,7 +185,7 @@ public struct W3WCoreColor: Equatable {
   public var color:   UIColor { get { return uiColor } }
   
 #if canImport(SwiftUI)
-  @available(iOS 13.0, *)
+  @available(iOS 13.0, watchOS 6.0, *)
   public var suColor: Color {
     get {
       return Color(uiColor)

--- a/Sources/W3WSwiftThemes/Extensions/UIColorExtension.swift
+++ b/Sources/W3WSwiftThemes/Extensions/UIColorExtension.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import UIKit
 
 extension UIColor {

--- a/Sources/W3WSwiftThemes/Graphics/W3WImage.swift
+++ b/Sources/W3WSwiftThemes/Graphics/W3WImage.swift
@@ -19,7 +19,7 @@ open class W3WImage {
   public var configuration: NSObject?
   
   #if canImport(UIKit)
-  @available(iOS 13.0, *)
+  @available(iOS 13.0, watchOS 6.0, *)
   public func setImageConfiguration(_ configuration: UIImage.Configuration) {
     self.configuration = configuration
   }
@@ -95,12 +95,16 @@ open class W3WImage {
   
   
   func from(file: String, size: W3WIconSize? = nil) -> UIImage {
-    guard let maskImage = UIImage(named: file, in: Bundle.module, compatibleWith: nil) else {
-      return UIImage()
-    }
+    #if os(watchOS)
+    guard let maskImage = UIImage(named: file, in: Bundle.module, with: nil) else { return UIImage() }
+    #else
+    guard let maskImage = UIImage(named: file, in: Bundle.module, compatibleWith: nil) else { return UIImage() }
+    #endif
+    #if canImport(UIKit) && !os(watchOS)
     if let color = colors?.foreground?.current.uiColor {
       return maskImage.mask(with: color, size: size?.value)
     }
+    #endif
     return maskImage
   }
   
@@ -109,7 +113,7 @@ open class W3WImage {
     var resultImage: UIImage? = nil
     
     // if SF Symbols can take multi-colour, and colours are available
-    if #available(iOS 15.0, *) {
+    if #available(iOS 15.0, watchOS 8.0, *) {
       var colorArray = [UIColor]()
       
       if let foreground = colors?.foreground?.current.uiColor {
@@ -133,7 +137,7 @@ open class W3WImage {
     
     // I think that there should be an "else" here, but no time to change and test ATM
 
-    else if #available(iOS 13.0, *) { // if we have SF Symbols available at all
+    else if #available(iOS 13.0, watchOS 6.0, *) { // if we have SF Symbols available at all
       // if there is a tint colour
       if let tint = colors?.tint?.current.uiColor {
         resultImage = UIImage(systemName: symbol)?.withTintColor(tint)
@@ -162,6 +166,8 @@ open class W3WImage {
 }
 
 
+// UIGraphicsBeginImageContextWithOptions and UIGraphicsImageRenderer are unavailable on watchOS
+#if canImport(UIKit) && !os(watchOS)
 extension UIImage {
   func mask(with color: UIColor, size: CGSize? = nil) -> UIImage {
     let targetSize = size ?? self.size
@@ -189,3 +195,4 @@ extension UIImage {
     }
   }
 }
+#endif

--- a/Sources/W3WSwiftThemes/Text/W3WFont.swift
+++ b/Sources/W3WSwiftThemes/Text/W3WFont.swift
@@ -165,7 +165,7 @@ extension W3WFont {
 #if canImport(SwiftUI)
 
 /// returns a UIFont colour
-@available(iOS 13.0, *)
+@available(iOS 13.0, watchOS 6.0, *)
 extension W3WFont {
   
   public var suFont: Font {


### PR DESCRIPTION
## What
Re-apply the watchOS support from **#78** (`task/support-watch-os`, tagged `1.5.1`) onto `main`:
- `Package.swift`: declare `platforms: [.watchOS(.v6)]`
- Restore watchOS availability guards in `W3WColor`, `W3WCoreColor`, `UIColorExtension`, `W3WImage`, `W3WFont`

## Why
`#78` (by Henry Ng) was tagged `1.5.1` but lives only on the `staging` / `task/support-watch-os` lineage — it was **never merged into `main`** (main diverged at #76, before #78). As a result a release cut from `main` (e.g. `1.6.0`) lacks watchOS support that `1.5.1` had, and the package fails to compile for watchOS:
- `Color` / `Font` / `Configuration` require watchOS 6.0 (no platform declared → default target too low)
- `UIUserInterfaceStyle` and the `UIGraphicsImageRenderer` image-masking are unavailable on watchOS (guards removed)

This breaks the iOS app's watch target when it builds themes from source.

## Test
- Built the full iOS app (incl. watch target) against this branch on iPhone 17 Pro simulator — **BUILD SUCCEEDED** (was failing with 6 watchOS errors before).

## Note
This is a port/re-apply of #78's changes; the underlying issue is that `main` and the release/`staging` lineage have diverged. Worth deciding how watch support should be kept in sync going forward.